### PR TITLE
Fix a kakan bug, now it behaves exactly as tensoul.

### DIFF
--- a/tensoul/model.py
+++ b/tensoul/model.py
@@ -159,8 +159,6 @@ class KakanSymbol(NamedTuple):
 
     def encode_tenhou(self) -> str:
         pos = self.feeder_relative
-        if pos == 2:
-            pos = 3
 
         t = [str(self.a.encode_tenhou()), str(self.b.encode_tenhou()), str(self.c.encode_tenhou())]
         t.insert(pos, f"k{self.tile.encode_tenhou()}")


### PR DESCRIPTION
Remove the uncorrect judging at kakan. As the example show below in tenhou.net/6/.

{"title":["",""],"name":["","","",""],"rule":{"aka":1},"log":[[[0,0,0],[25000,25000,25000,25000],[41],[],[11,11,12,13,14,15,16,17,18,41,41,41,24],[31,"1111p11",11,24],[31,12,"1111k1111"],[11,12,13,14,15,16,17,18,19,29,28,27,27],[31,42],[11,12],[33,12,13,14,14,16,17,17,18,19,51,52,29],[21],[33],[12,13,22,22,25,26,28,29,34,35,38,37,38],[42],[42],["不明"]]]}