### PR TITLE
Fix pao counting

### DIFF
--- a/tensoul/parser.py
+++ b/tensoul/parser.py
@@ -109,7 +109,7 @@ class MajsoulPaipuParser:
                 self.paowind = feeder
         elif 5 <= tile.num <= 7:
             self.nodrags[owner] += 1
-            if self.nodrags[owner] == 4:
+            if self.nodrags[owner] == 3:
                 self.paodrag = feeder
 
     def _handle_chi_peng_gang(self, log):


### PR DESCRIPTION
修复无法正确计算大三元包牌的问题，例如雀魂牌谱240118-6f816400-0580-4b44-9557-411375773c0c的最后一局。