### PR TITLE
Fix kakan event missing

### DIFF
--- a/tensoul/parser.py
+++ b/tensoul/parser.py
@@ -150,7 +150,7 @@ class MajsoulPaipuParser:
             # kakan
             # find pon and swap in new symbol
             for sy in self.cur.draws[log.seat]:
-                if isinstance(sy, PonSymbol) and (sy.tile == tile or sy.tile == tile.deaka()):
+                if isinstance(sy, PonSymbol) and (sy.tile.deaka() == tile.deaka()):
                     self.cur.discards[log.seat].append(KakanSymbol(sy.a, sy.b, sy.tile, tile, sy.feeder_relative))
                     self.nkan += 1
                     break


### PR DESCRIPTION
修复碰牌进张为赤宝牌时，无法正确开杠的问题，例如雀魂牌谱240105-4b3497ed-5e0b-46cd-9aee-977d3da5739d中第二局的开杠。